### PR TITLE
chore(deps): bump koin to 2.2.2, change koin maven group id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_ktx_version"
 
     // Koin
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
 
     // Retrofit, Moshi
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     ext.kotlin_version = '1.4.31'
-    ext.koin_version = '2.2.0'
+    ext.koin_version = '2.2.2'
     ext.retrofit_version = '2.9.0'
     ext.lifecycle_ktx_version = '2.3.1'
     ext.room_version = "2.2.6"
     ext.moshi_version="1.11.0"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -20,6 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 }


### PR DESCRIPTION
Koin moved from jcenter to maven central.
koin.org changed their domain to insert-koin.io, which affects the group id.